### PR TITLE
flush output buffers and disconnect

### DIFF
--- a/src/AbstractSapiEmitter.php
+++ b/src/AbstractSapiEmitter.php
@@ -40,7 +40,7 @@ abstract class AbstractSapiEmitter implements EmitterInterface
      *
      * It's important to mention that, in order to prevent PHP from changing
      * the status code of the emitted response, this method should be called
-     * after `sendBody()`
+     * after `emitBody()`
      *
      * @param \Psr\Http\Message\ResponseInterface $response
      *
@@ -113,5 +113,22 @@ abstract class AbstractSapiEmitter implements EmitterInterface
         $filtered = \ucwords($filtered);
 
         return \str_replace(' ', '-', $filtered);
+    }
+
+    /**
+     * Flushes output buffers and closes the connection to the client,
+     * which ensures that no further output can be sent.
+     *
+     * @return void
+     */
+    protected function closeConnection(): void
+    {
+        if (! \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
+            Util::closeOutputBuffers(0, true);
+        }
+
+        if (\function_exists('fastcgi_finish_request')) {
+            \fastcgi_finish_request();
+        }
     }
 }

--- a/src/SapiEmitter.php
+++ b/src/SapiEmitter.php
@@ -18,7 +18,9 @@ class SapiEmitter extends AbstractSapiEmitter
         // Set the status _after_ the headers, because of PHP's "helpful" behavior with location headers.
         $this->emitStatusLine($response);
 
-        $this->sendBody($response);
+        $this->emitBody($response);
+
+        $this->closeConnection();
     }
 
     /**
@@ -26,7 +28,7 @@ class SapiEmitter extends AbstractSapiEmitter
      *
      * @param \Psr\Http\Message\ResponseInterface $response
      */
-    private function sendBody(ResponseInterface $response): void
+    private function emitBody(ResponseInterface $response): void
     {
         echo $response->getBody();
     }

--- a/src/SapiStreamEmitter.php
+++ b/src/SapiStreamEmitter.php
@@ -43,11 +43,11 @@ class SapiStreamEmitter extends AbstractSapiEmitter
 
         if (\is_array($range) && $range[0] === 'bytes') {
             $this->emitBodyRange($range, $response, $this->maxBufferLength);
-
-            return;
+        } else {
+            $this->emitBody($response, $this->maxBufferLength);
         }
 
-        $this->sendBody($response, $this->maxBufferLength);
+        $this->closeConnection();
     }
 
     /**
@@ -56,7 +56,7 @@ class SapiStreamEmitter extends AbstractSapiEmitter
      * @param \Psr\Http\Message\ResponseInterface $response
      * @param int                                 $maxBufferLength
      */
-    private function sendBody(ResponseInterface $response, int $maxBufferLength): void
+    private function emitBody(ResponseInterface $response, int $maxBufferLength): void
     {
         $body = $response->getBody();
 


### PR DESCRIPTION
Fixes #12 

I didn't implement this *quite* as proposed - two minor differences:

1. Your reference code either flushed output buffers or closed the connection - I believe it needs to do both. (closing the connection would be problematic if there's still content waiting in the buffer.)

2. Placement of the `closeConnection()` calls is a bit different than I proposed - I had missed a `return` statement. (I unrolled an `if/return` to an `if/else` to make sure `closeConnection()` gets called in either case.)
